### PR TITLE
Fix typo for PacketAudio4

### DIFF
--- a/demux.go
+++ b/demux.go
@@ -23,7 +23,7 @@ const (
 	PacketAudio1  = 0xC0
 	PacketAudio2  = 0xC1
 	PacketAudio3  = 0xC2
-	PacketAudio4  = 0xC2
+	PacketAudio4  = 0xC3
 	PacketVideo1  = 0xE0
 )
 


### PR DESCRIPTION
I think that the fact that other parts of the code use `PacketAudio1 + m.audioStreamIndex` justifies the correctness of the change. But I also looked at http://andrewduncan.net/mpeg/mpeg-1.html (see the 4th slide "MPEG-1 Packet").