### PR TITLE
Add (*Buffer).read1 for 1bit reading

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -250,7 +250,7 @@ func (a *Audio) decodeHeader() int {
 
 	a.version = a.buf.read(2)
 	a.layer = a.buf.read(2)
-	hasCRC := a.buf.read(1) == 0
+	hasCRC := a.buf.read1() == 0
 
 	if a.version != mpeg1 || a.layer != layerII {
 		return 0
@@ -266,7 +266,7 @@ func (a *Audio) decodeHeader() int {
 		return 0
 	}
 
-	padding := a.buf.read(1)
+	padding := a.buf.read1()
 	a.buf.skip(1) // f_private
 	mode := a.buf.read(2)
 

--- a/buffer.go
+++ b/buffer.go
@@ -257,6 +257,21 @@ func (b *Buffer) read(count int) int {
 	return value
 }
 
+func (b *Buffer) read1() int {
+	if !b.has(1) {
+		return 0
+	}
+
+	currentByte := int(b.Bytes()[b.bitIndex>>3])
+
+	shift := 7 - (b.bitIndex & 7)
+	value := (currentByte & (1 << shift)) >> shift
+
+	b.bitIndex += 1
+
+	return value
+}
+
 func (b *Buffer) align() {
 	b.bitIndex = ((b.bitIndex + 7) >> 3) << 3 // Align to next byte
 }
@@ -351,7 +366,7 @@ func (b *Buffer) readVlc(table []vlc) int {
 	var state vlc
 
 	for {
-		state = table[int(state.Index)+b.read(1)]
+		state = table[int(state.Index)+b.read1()]
 		if state.Index <= 0 {
 			break
 		}
@@ -364,7 +379,7 @@ func (b *Buffer) readVlcUint(table []vlcUint) uint16 {
 	var state vlcUint
 
 	for {
-		state = table[int(state.Index)+b.read(1)]
+		state = table[int(state.Index)+b.read1()]
 		if state.Index <= 0 {
 			break
 		}

--- a/video.go
+++ b/video.go
@@ -293,7 +293,7 @@ func (v *Video) decodeSequenceHeader() bool {
 	v.buf.skip(1 + 10 + 1)
 
 	// Load custom intra quant matrix?
-	if v.buf.read(1) != 0 {
+	if v.buf.read1() != 0 {
 		for i := 0; i < 64; i++ {
 			idx := videoZigZag[i]
 			v.intraQuantMatrix[idx] = byte(v.buf.read(8))
@@ -303,7 +303,7 @@ func (v *Video) decodeSequenceHeader() bool {
 	}
 
 	// Load custom non intra quant matrix?
-	if v.buf.read(1) != 0 {
+	if v.buf.read1() != 0 {
 		for i := 0; i < 64; i++ {
 			idx := videoZigZag[i]
 			v.nonIntraQuantMatrix[idx] = byte(v.buf.read(8))
@@ -382,7 +382,7 @@ func (v *Video) decodePicture() {
 
 	// Forward fullPx, fCode
 	if v.pictureType == pictureTypePredictive || v.pictureType == pictureTypeB {
-		v.motionForward.FullPx = v.buf.read(1)
+		v.motionForward.FullPx = v.buf.read1()
 		fCode := v.buf.read(3)
 		if fCode == 0 {
 			// Ignore picture with zero fCode
@@ -393,7 +393,7 @@ func (v *Video) decodePicture() {
 
 	// Backward fullPx, fCode
 	if v.pictureType == pictureTypeB {
-		v.motionBackward.FullPx = v.buf.read(1)
+		v.motionBackward.FullPx = v.buf.read1()
 		fCode := v.buf.read(3)
 		if fCode == 0 {
 			// Ignore picture with zero fCode
@@ -446,7 +446,7 @@ func (v *Video) decodeSlice(slice int) {
 	v.quantizerScale = v.buf.read(5)
 
 	// Skip extra
-	for v.buf.read(1) != 0 {
+	for v.buf.read1() != 0 {
 		v.buf.skip(8)
 	}
 
@@ -948,7 +948,7 @@ func (v *Video) decodeBlock(block int) {
 		run := 0
 		coeff := int(v.buf.readVlcUint(videoDctCoeff))
 
-		if (coeff == 0x0001) && (n > 0) && (v.buf.read(1) == 0) {
+		if (coeff == 0x0001) && (n > 0) && (v.buf.read1() == 0) {
 			// end_of_block
 			break
 		}
@@ -968,7 +968,7 @@ func (v *Video) decodeBlock(block int) {
 		} else {
 			run = coeff >> 8
 			level = coeff & 0xff
-			if (v.buf.read(1)) != 0 {
+			if (v.buf.read1()) != 0 {
 				level = -level
 			}
 		}


### PR DESCRIPTION
(*Buffer).read(1) is a hot spot and called mainly by readVlcUint when decoding a video.

This change adds an optimized reading function for reading one bit. This reduces time of decoding video by ~~7-8%~~ 12%.

```
goos: darwin
goarch: arm64
pkg: github.com/gen2brain/mpeg
               │   old.txt   │               new.txt               │
               │   sec/op    │   sec/op     vs base                │
DecodeVideo-12   86.42µ ± 1%   76.02µ ± 2%  -12.03% (p=0.000 n=10)
DecodeAudio-12   48.00µ ± 2%   47.09µ ± 3%   -1.90% (p=0.002 n=10)
RGBA-12          40.86µ ± 1%   41.62µ ± 1%   +1.87% (p=0.002 n=10)
geomean          55.34µ        53.01µ        -4.20%

               │  old.txt   │              new.txt               │
               │    B/op    │    B/op     vs base                │
DecodeVideo-12   84.00 ± 1%   75.00 ± 1%  -10.71% (p=0.000 n=10)
DecodeAudio-12   47.00 ± 2%   46.00 ± 2%        ~ (p=0.291 n=10)
RGBA-12          40.00 ± 2%   41.00 ± 0%        ~ (p=0.057 n=10)
geomean          54.05        52.10        -3.60%

               │   old.txt    │               new.txt               │
               │  allocs/op   │ allocs/op   vs base                 │
DecodeVideo-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecodeAudio-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
RGBA-12          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                     ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```